### PR TITLE
Fix error check on SetInitialWallpaper

### DIFF
--- a/eventloop.go
+++ b/eventloop.go
@@ -249,7 +249,9 @@ func (stw *Wallpaper) EventLoop(verbose bool, setWallpaperFunc func(string) erro
 		fmt.Println("Using the Simple Timed Wallpaper format.")
 	}
 
-	stw.SetInitialWallpaper(verbose, setWallpaperFunc)
+	if err := stw.SetInitialWallpaper(verbose, setWallpaperFunc); err != nil {
+		fmt.Print(err)
+	}
 
 	eventloop := event.NewLoop()
 


### PR DESCRIPTION
Hi,
you are never checking error there, so after running loop all looks ok, even when stw file has wrong image paths.